### PR TITLE
Add Headers to error response

### DIFF
--- a/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/BaseApiRequestHandler.kt
+++ b/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/BaseApiRequestHandler.kt
@@ -40,7 +40,7 @@ abstract class BaseApiRequestHandler<T>(
         return when (throwable) {
             is HttpException -> handleHttpException(throwable)
             is IOException   -> ConnectionError(ErrorResponse(throwable))
-            else             -> UnknownError
+            else             -> UnknownError(ErrorResponse(throwable))
         }
     }
 
@@ -48,7 +48,7 @@ abstract class BaseApiRequestHandler<T>(
         return when (exception.code()) {
             in (400 until 500) -> handleBadRequest(exception)
             in (500 until 600) -> ServerError(ErrorResponse(exception, exception.headers()))
-            else               -> UnknownError
+            else               -> UnknownError(ErrorResponse(exception))
         }
     }
 
@@ -65,7 +65,7 @@ abstract class BaseApiRequestHandler<T>(
         return if (errors != null) {
             createRequestError(errors)
         } else {
-            UnknownError
+            UnknownError(ErrorResponse(exception))
         }
     }
 

--- a/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/Headers.kt
+++ b/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/Headers.kt
@@ -1,0 +1,19 @@
+package com.maciejkozlowski.coroutineapihandler
+
+import okhttp3.Headers
+
+class Headers(
+        private val headers: Headers
+) {
+
+    /**
+     * @return The last value corresponding to the specified field, or null.
+     */
+    operator fun get(name: String): String? {
+        return headers[name]
+    }
+
+    fun toMultiMap(): Map<String, List<String>> {
+        return headers.toMultimap()
+    }
+}

--- a/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/HttpExceptionExt.kt
+++ b/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/HttpExceptionExt.kt
@@ -1,8 +1,3 @@
-/*
- * Copyright (c) 2020. CoinTracking.
- * Created by Alejandro Ramos, Citruslab, LLC
- */
-
 package com.maciejkozlowski.coroutineapihandler
 
 import okhttp3.Headers

--- a/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/HttpExceptionExt.kt
+++ b/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/HttpExceptionExt.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2020. CoinTracking.
+ * Created by Alejandro Ramos, Citruslab, LLC
+ */
+
+package com.maciejkozlowski.coroutineapihandler
+
+import okhttp3.Headers
+import retrofit2.HttpException
+
+internal fun HttpException.headers(): Headers? {
+    return response()?.headers()
+}

--- a/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/ApiError.kt
+++ b/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/ApiError.kt
@@ -3,4 +3,4 @@ package com.maciejkozlowski.coroutineapihandler.errors
 /**
  * Created by Maciej Kozłowski on 2019-04-30.
  */
-interface ApiError
+abstract class ApiError(val errorResponse: ErrorResponse? = null)

--- a/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/ConnectionError.kt
+++ b/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/ConnectionError.kt
@@ -1,3 +1,3 @@
 package com.maciejkozlowski.coroutineapihandler.errors
 
-object ConnectionError : ApiError
+class ConnectionError(errorResponse: ErrorResponse) : ApiError(errorResponse)

--- a/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/ErrorResponse.kt
+++ b/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/ErrorResponse.kt
@@ -1,0 +1,12 @@
+package com.maciejkozlowski.coroutineapihandler.errors
+
+import com.maciejkozlowski.coroutineapihandler.Headers
+
+
+data class ErrorResponse(
+        val throwable: Throwable? = null,
+        val headers: Headers? = null
+) {
+    internal constructor(throwable: Throwable?, headers: okhttp3.Headers?)
+            : this(throwable, headers?.let { Headers(it) })
+}

--- a/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/ServerError.kt
+++ b/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/ServerError.kt
@@ -1,3 +1,3 @@
 package com.maciejkozlowski.coroutineapihandler.errors
 
-object ServerError : ApiError
+class ServerError(errorResponse: ErrorResponse) : ApiError(errorResponse)

--- a/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/UnauthorizedError.kt
+++ b/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/UnauthorizedError.kt
@@ -1,3 +1,3 @@
 package com.maciejkozlowski.coroutineapihandler.errors
 
-object UnauthorizedError : ApiError
+class UnauthorizedError(errorResponse: ErrorResponse) : ApiError(errorResponse)

--- a/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/UnknownError.kt
+++ b/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/UnknownError.kt
@@ -1,3 +1,3 @@
 package com.maciejkozlowski.coroutineapihandler.errors
 
-data class UnknownError(val throwable: Throwable) : ApiError
+object UnknownError : ApiError()

--- a/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/UnknownError.kt
+++ b/coroutineapihandler/src/main/java/com/maciejkozlowski/coroutineapihandler/errors/UnknownError.kt
@@ -1,3 +1,3 @@
 package com.maciejkozlowski.coroutineapihandler.errors
 
-object UnknownError : ApiError()
+class UnknownError(errorResponse: ErrorResponse) : ApiError(errorResponse)


### PR DESCRIPTION
Now `ApiError` and classes inheriting from it, contains optional `ErrorResponse`
```kotlin
data class ErrorResponse(
        val throwable: Throwable? = null,
        val headers: Headers? = null
)
```

`ErrorResponse` has `Throwable` which occurred during network call, and `Headers` which are proxy for `okhttp3.Headers`

```kotlin
import okhttp3.Headers

class Headers(
        private val headers: Headers    // okhttp3.Headers
) {

    /**
     * @return The last value corresponding to the specified field, or null.
     */
    operator fun get(name: String): String? {
        return headers[name]
    }

    fun toMultiMap(): Map<String, List<String>> {
        return headers.toMultimap()
    }
}
```